### PR TITLE
Attempt to fix popover rotation

### DIFF
--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -2863,7 +2863,7 @@ static CGPoint WYPointRelativeToOrientation(CGPoint origin, CGSize size, UIInter
   
   WY_LOG(@"Queue change to orientation %@ with frame %@", WYStringFromOrientation(orientation), NSStringFromCGRect(orientationFrame));
   
-  dispatch_sync(orientationSyncQueue, ^{
+  dispatch_async(orientationSyncQueue, ^{
     
     WY_LOG(@"Will change to orientation %@", WYStringFromOrientation(orientation));
     

--- a/WYPopoverController/WYPopoverController.m
+++ b/WYPopoverController/WYPopoverController.m
@@ -1428,7 +1428,6 @@ static float edgeSizeFromCornerRadius(float cornerRadius) {
   BOOL                     _animated;
   BOOL                     _isListeningNotifications;
   BOOL                     _isObserverAdded;
-  BOOL                     _isInterfaceOrientationChanging;
   BOOL                     _ignoreOrientation;
   __weak UIBarButtonItem  *_barButtonItem;
 


### PR DESCRIPTION
- Merged both notifications in a single method
- Usage of device methods to enable and disable orientation notifications
- Usage of queue to handle all the requested rotations
- Stored and sent to block current view frames and orientations when orientation changed callback is fired
